### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactnativeVersion', '+')}"
-    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.0'
+    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.1'
     implementation group: 'com.heroku.sdk', name: 'env-keystore', version: '1.0.4'
 }
 


### PR DESCRIPTION
Use 1.2.1 instead to avoid following error:

MqttConnectOptions.setUserName in 1.2.0 has a empty string check(removed by [commit](https://github.com/eclipse/paho.mqtt.java/commit/d760280207248666a41e73cfc86555c140cdf3d8)  ):
```
	public void setUserName(String userName) {
		if ((userName != null) && (userName.trim().equals(""))) {
			throw new IllegalArgumentException();
		}
		this.userName = userName;
	}
```


while the `connect` method in `MqttClient` will give "" as default value for username:

`            connOpts.setUserName(options.hasKey("username") ? options.getString("username") : "");
`

Which result to an `IllegalArgumentException`